### PR TITLE
Added single quotes check when path to the program has spaces

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -9,6 +9,7 @@ using System.Windows.Forms;
 using System.Linq;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace SingleInstanceArgAggregator
 {
@@ -104,6 +105,15 @@ Usage:
         //we drop out here when the form closes upon timer expiration
 
         var cmd = cmdLine.Split(' ')[0];
+
+        Regex regex = new Regex("'(.*?)'");
+        var matches = regex.Matches(cmdLine);
+        if (matches.Count > 0)  //if there is text inside single quotes use that as a cmd...
+        {
+            cmdLine = cmdLine.Replace("'", "");
+            cmd = matches[0].Groups[1].ToString();
+        }
+
         var args = cmdLine.Substring(cmd.Length + 1);
 
         string output = null;


### PR DESCRIPTION
Hello I don't know if you noticed but when you call `SingleInstanceAccumulator.exe -q:' "-c:C:\Users\some folder\test.exe $files` it just splits cmdLine where the " " is and it tries to start the process with file name, in this case, `C:\Users\some` instead of `C:\Users\some folder\test.exe`
I added regex check to see if there is text at the beginning of cmdLine inside single quotes and it uses it as filename.
Now you can use `-c:C:\Without_spaces_no_quotes\test.exe $files` or if you have space in you path then `-c:'C:\With spaces and 
 quotes\test.exe' $files` 